### PR TITLE
feat: support absolute dist paths and use absWorkingDir is present

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -172,9 +172,16 @@ export default function esbuildPluginPino({
 
         const contents = await readFile(args.path, 'utf8')
 
-        const absoluteOutputPath = `\${process.cwd()}\${require('path').sep}${
-          currentBuild.initialOptions.outdir || 'dist'
-        }`
+        let absoluteOutputPath = "";
+        const { outdir = "dist" } = currentBuild.initialOptions;
+        if(path.isAbsolute(outdir)){
+          absoluteOutputPath = outdir.replace(/\\/g, "\\\\");
+        } else {
+          const workingDir = currentBuild.initialOptions.absWorkingDir ? `"${currentBuild.initialOptions.absWorkingDir.replace(/\\/g, "\\\\")}"` : "process.cwd()";
+          absoluteOutputPath = `\${${workingDir}}\${require('path').sep}${
+            currentBuild.initialOptions.outdir || 'dist'
+          }`
+        }
 
         const functionDeclaration = `
           function pinoBundlerAbsolutePath(p) {


### PR DESCRIPTION
This PR adds the support for 2 esbuild options:
 
1. absolute `outdir` - if outdir is absolute, it should take it as is, instead of building a new path. The previous behavior simply concatenates the two absolute paths making them and invalid path.
2. If `absWorkingDir` option is provided, it should take it instead of `process.cwd()` - so you can run the build script from an entirely separate location than the built module. 

In addition, this PR fixes windows-style paths (with `\` separator)